### PR TITLE
Fix issue #86 in Claude code plugin

### DIFF
--- a/agent-builder/hooks/hooks.json
+++ b/agent-builder/hooks/hooks.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PROJECT_DIR/agent-builder/hooks/scripts/check-skill-invoked.py"
+            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/check-skill-invoked.py"
           }
         ]
       },


### PR DESCRIPTION
Fix the PreToolUse hook to use $CLAUDE_PLUGIN_ROOT instead of $CLAUDE_PROJECT_DIR when referencing the check-skill-invoked.py script.

This resolves the issue where Write operations were blocked in projects that don't have a local agent-builder/ directory structure.

Fixes #86