### PR TITLE
Validate and fix issue #89

### DIFF
--- a/github-workflows/hooks/scripts/check-dependencies.sh
+++ b/github-workflows/hooks/scripts/check-dependencies.sh
@@ -1,36 +1,69 @@
 #!/bin/bash
 # Check and install required dependencies for github-workflows plugin
+# SessionStart hook - MUST output valid JSON to stdout
+
+set -euo pipefail
+
+# Function to output JSON and exit
+output_json() {
+    local decision="$1"
+    local reason="${2:-}"
+    if [ -n "$reason" ]; then
+        printf '{"decision": "%s", "reason": "%s"}\n' "$decision" "$reason" | tr -d '\r'
+    else
+        printf '{"decision": "%s"}\n' "$decision" | tr -d '\r'
+    fi
+}
 
 check_and_install_jq() {
     if command -v jq &> /dev/null; then
         return 0
     fi
 
-    echo "jq not found. Attempting to install..."
+    # All informational output goes to stderr, not stdout
+    echo "jq not found. Attempting to install..." >&2
 
     # Detect OS and install
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS
         if command -v brew &> /dev/null; then
-            brew install jq && echo "Success: jq installed via Homebrew" && return 0
+            if brew install jq >&2 2>&1; then
+                echo "Success: jq installed via Homebrew" >&2
+                return 0
+            fi
         else
-            echo "Warning: Homebrew not found. Install jq manually: brew install jq"
+            echo "Warning: Homebrew not found. Install jq manually: brew install jq" >&2
             return 1
         fi
     elif [[ -f /etc/debian_version ]]; then
         # Debian/Ubuntu/WSL
-        sudo apt-get update -qq && sudo apt-get install -y -qq jq && echo "Success: jq installed via apt" && return 0
+        if sudo apt-get update -qq >&2 2>&1 && sudo apt-get install -y -qq jq >&2 2>&1; then
+            echo "Success: jq installed via apt" >&2
+            return 0
+        fi
     elif [[ -f /etc/fedora-release ]] || [[ -f /etc/redhat-release ]]; then
         # Fedora/RHEL
-        sudo dnf install -y jq && echo "Success: jq installed via dnf" && return 0
+        if sudo dnf install -y jq >&2 2>&1; then
+            echo "Success: jq installed via dnf" >&2
+            return 0
+        fi
     elif [[ -f /etc/arch-release ]]; then
         # Arch
-        sudo pacman -S --noconfirm jq && echo "Success: jq installed via pacman" && return 0
+        if sudo pacman -S --noconfirm jq >&2 2>&1; then
+            echo "Success: jq installed via pacman" >&2
+            return 0
+        fi
     else
-        echo "Warning: Could not auto-install jq. Please install manually for your OS."
+        echo "Warning: Could not auto-install jq. Please install manually for your OS." >&2
         return 1
     fi
+    return 1
 }
 
-# Run checks
-check_and_install_jq
+# Run checks and output JSON result
+if check_and_install_jq; then
+    output_json "approve" "Dependencies checked successfully"
+else
+    # Even if jq install fails, approve the session but warn
+    output_json "approve" "jq not available - some features may be limited"
+fi


### PR DESCRIPTION
The github-workflows check-dependencies.sh script was outputting plain text instead of JSON, causing the CLI to fail when parsing the hook response. The self-improvement load-learnings.sh script also needed safeguards to ensure only JSON is sent to stdout.

Changes:
- github-workflows: Redirect all informational output to stderr
- github-workflows: Add output_json function for consistent JSON output
- self-improvement: Add error trap that outputs valid JSON on failure
- self-improvement: Filter Python output to extract only JSON lines
- self-improvement: Add fallback JSON response if no valid output found

Fixes #89